### PR TITLE
Fixes cat color (variant) metadata, adds frog meta

### DIFF
--- a/src/main/java/net/minestom/server/entity/EntityTypeImpl.java
+++ b/src/main/java/net/minestom/server/entity/EntityTypeImpl.java
@@ -107,7 +107,7 @@ record EntityTypeImpl(Registry.EntityEntry registry) implements EntityType {
                 entry("minecraft:falling_block", FallingBlockMeta::new),
                 entry("minecraft:firework_rocket", FireworkRocketMeta::new),
                 entry("minecraft:fox", FoxMeta::new),
-                entry("minecraft:frog", EntityMeta::new), // TODO dedicated metadata
+                entry("minecraft:frog", FrogMeta::new),
                 entry("minecraft:ghast", GhastMeta::new),
                 entry("minecraft:giant", GiantMeta::new),
                 entry("minecraft:glow_item_frame", GlowItemFrameMeta::new),

--- a/src/main/java/net/minestom/server/entity/Metadata.java
+++ b/src/main/java/net/minestom/server/entity/Metadata.java
@@ -101,7 +101,7 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_POSE, value, NetworkBuffer.POSE);
     }
 
-    public static Entry<CatMeta.Color> CatVariant(@NotNull CatMeta.Color value) {
+    public static Entry<CatMeta.Variant> CatVariant(@NotNull CatMeta.Variant value) {
         return new MetadataImpl.EntryImpl<>(TYPE_CAT_VARIANT, value, NetworkBuffer.CAT_VARIANT);
     }
 

--- a/src/main/java/net/minestom/server/entity/Metadata.java
+++ b/src/main/java/net/minestom/server/entity/Metadata.java
@@ -2,6 +2,8 @@ package net.minestom.server.entity;
 
 import net.kyori.adventure.text.Component;
 import net.minestom.server.coordinate.Point;
+import net.minestom.server.entity.metadata.animal.FrogMeta;
+import net.minestom.server.entity.metadata.animal.tameable.CatMeta;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.NetworkBuffer;
 import net.minestom.server.network.packet.server.play.EntityMetaDataPacket;
@@ -99,6 +101,14 @@ public final class Metadata {
         return new MetadataImpl.EntryImpl<>(TYPE_POSE, value, NetworkBuffer.POSE);
     }
 
+    public static Entry<CatMeta.Color> CatVariant(@NotNull CatMeta.Color value) {
+        return new MetadataImpl.EntryImpl<>(TYPE_CAT_VARIANT, value, NetworkBuffer.CAT_VARIANT);
+    }
+
+    public static Entry<FrogMeta.Variant> FrogVariant(@NotNull FrogMeta.Variant value) {
+        return new MetadataImpl.EntryImpl<>(TYPE_FROG_VARIANT, value, NetworkBuffer.FROG_VARIANT);
+    }
+
     public static final byte TYPE_BYTE = 0;
     public static final byte TYPE_VARINT = 1;
     public static final byte TYPE_LONG = 2;
@@ -119,6 +129,8 @@ public final class Metadata {
     public static final byte TYPE_VILLAGERDATA = 17;
     public static final byte TYPE_OPTVARINT = 18;
     public static final byte TYPE_POSE = 19;
+    public static final byte TYPE_CAT_VARIANT = 20;
+    public static final byte TYPE_FROG_VARIANT = 21;
 
     private static final VarHandle NOTIFIED_CHANGES;
 

--- a/src/main/java/net/minestom/server/entity/metadata/animal/FrogMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/FrogMeta.java
@@ -1,0 +1,38 @@
+package net.minestom.server.entity.metadata.animal;
+
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.Metadata;
+import org.jetbrains.annotations.NotNull;
+
+public class FrogMeta extends AnimalMeta {
+    public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
+    public static final byte MAX_OFFSET = OFFSET + 2;
+
+    public FrogMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+        super(entity, metadata);
+    }
+
+    public Variant getVariant() {
+        return super.metadata.getIndex(OFFSET, Variant.TEMPERATE);
+    }
+
+    public void setVariant(@NotNull Variant value) {
+        super.metadata.setIndex(OFFSET, Metadata.FrogVariant(value));
+    }
+
+    public int getTongueTarget() {
+        return super.metadata.getIndex(OFFSET + 1, 0);
+    }
+
+    public void setTongueTarget(int value) {
+        super.metadata.setIndex(OFFSET + 1, Metadata.OptVarInt(value));
+    }
+
+    public enum Variant {
+        TEMPERATE,
+        WARM,
+        COLD;
+
+        private final static FrogMeta.Variant[] VALUES = values();
+    }
+}

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/CatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/CatMeta.java
@@ -1,5 +1,6 @@
 package net.minestom.server.entity.metadata.animal.tameable;
 
+import net.minestom.server.color.DyeColor;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Metadata;
 import org.jetbrains.annotations.NotNull;
@@ -8,16 +9,18 @@ public class CatMeta extends TameableAnimalMeta {
     public static final byte OFFSET = TameableAnimalMeta.MAX_OFFSET;
     public static final byte MAX_OFFSET = OFFSET + 4;
 
+    private static final DyeColor[] DYE_VALUES = DyeColor.values();
+
     public CatMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
         super(entity, metadata);
     }
 
     @NotNull
-    public Color getColor() {
-        return super.metadata.getIndex(OFFSET, Color.BLACK);
+    public CatMeta.Variant getVariant() {
+        return super.metadata.getIndex(OFFSET, Variant.BLACK);
     }
 
-    public void setColor(@NotNull Color value) {
+    public void setVariant(@NotNull CatMeta.Variant value) {
         super.metadata.setIndex(OFFSET, Metadata.CatVariant(value));
     }
 
@@ -37,15 +40,15 @@ public class CatMeta extends TameableAnimalMeta {
         super.metadata.setIndex(OFFSET + 2, Metadata.Boolean(value));
     }
 
-    public int getCollarColor() {
-        return super.metadata.getIndex(OFFSET + 3, 14);
+    public @NotNull DyeColor getCollarColor() {
+        return DYE_VALUES[super.metadata.getIndex(OFFSET + 3, DyeColor.RED.ordinal())];
     }
 
-    public void setCollarColor(int value) {
-        super.metadata.setIndex(OFFSET + 3, Metadata.VarInt(value));
+    public void setCollarColor(@NotNull DyeColor value) {
+        super.metadata.setIndex(OFFSET + 3, Metadata.VarInt(value.ordinal()));
     }
 
-    public enum Color {
+    public enum Variant {
         TABBY,
         BLACK,
         RED,
@@ -58,7 +61,7 @@ public class CatMeta extends TameableAnimalMeta {
         JELLIE,
         ALL_BLACK;
 
-        private final static Color[] VALUES = values();
+        private static final Variant[] VALUES = values();
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/animal/tameable/CatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/tameable/CatMeta.java
@@ -14,11 +14,11 @@ public class CatMeta extends TameableAnimalMeta {
 
     @NotNull
     public Color getColor() {
-        return Color.VALUES[super.metadata.getIndex(OFFSET, 1)];
+        return super.metadata.getIndex(OFFSET, Color.BLACK);
     }
 
     public void setColor(@NotNull Color value) {
-        super.metadata.setIndex(OFFSET, Metadata.VarInt(value.ordinal()));
+        super.metadata.setIndex(OFFSET, Metadata.CatVariant(value));
     }
 
     public boolean isLying() {

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -3,6 +3,8 @@ package net.minestom.server.network;
 import net.kyori.adventure.text.Component;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.metadata.animal.FrogMeta;
+import net.minestom.server.entity.metadata.animal.tameable.CatMeta;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.network.packet.server.play.data.DeathLocation;
 import net.minestom.server.utils.Direction;
@@ -57,6 +59,8 @@ public final class NetworkBuffer {
     public static final Type<Integer> OPT_VAR_INT = NetworkBufferTypes.OPT_VAR_INT;
     public static final Type<Entity.Pose> POSE = NetworkBufferTypes.POSE;
     public static final Type<DeathLocation> DEATH_LOCATION = NetworkBufferTypes.DEATH_LOCATION;
+    public static final Type<CatMeta.Color> CAT_VARIANT = NetworkBufferTypes.CAT_VARIANT;
+    public static final Type<FrogMeta.Variant> FROG_VARIANT = NetworkBufferTypes.FROG_VARIANT;
 
     ByteBuffer nioBuffer;
     final boolean resizable;

--- a/src/main/java/net/minestom/server/network/NetworkBuffer.java
+++ b/src/main/java/net/minestom/server/network/NetworkBuffer.java
@@ -59,7 +59,7 @@ public final class NetworkBuffer {
     public static final Type<Integer> OPT_VAR_INT = NetworkBufferTypes.OPT_VAR_INT;
     public static final Type<Entity.Pose> POSE = NetworkBufferTypes.POSE;
     public static final Type<DeathLocation> DEATH_LOCATION = NetworkBufferTypes.DEATH_LOCATION;
-    public static final Type<CatMeta.Color> CAT_VARIANT = NetworkBufferTypes.CAT_VARIANT;
+    public static final Type<CatMeta.Variant> CAT_VARIANT = NetworkBufferTypes.CAT_VARIANT;
     public static final Type<FrogMeta.Variant> FROG_VARIANT = NetworkBufferTypes.FROG_VARIANT;
 
     ByteBuffer nioBuffer;

--- a/src/main/java/net/minestom/server/network/NetworkBufferTypes.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferTypes.java
@@ -525,14 +525,14 @@ final class NetworkBufferTypes {
                 }
                 return null;
             });
-    static final TypeImpl<CatMeta.Color> CAT_VARIANT = new TypeImpl<>(CatMeta.Color.class,
+    static final TypeImpl<CatMeta.Variant> CAT_VARIANT = new TypeImpl<>(CatMeta.Variant.class,
             (buffer, value) -> {
                 buffer.write(VAR_INT, value.ordinal());
                 return -1;
             },
             buffer -> {
                 final int ordinal = buffer.read(VAR_INT);
-                return CatMeta.Color.values()[ordinal];
+                return CatMeta.Variant.values()[ordinal];
             });
     static final TypeImpl<FrogMeta.Variant> FROG_VARIANT = new TypeImpl<>(FrogMeta.Variant.class,
             (buffer, value) -> {

--- a/src/main/java/net/minestom/server/network/NetworkBufferTypes.java
+++ b/src/main/java/net/minestom/server/network/NetworkBufferTypes.java
@@ -5,6 +5,8 @@ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.metadata.animal.FrogMeta;
+import net.minestom.server.entity.metadata.animal.tameable.CatMeta;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.network.packet.server.play.data.DeathLocation;
@@ -522,6 +524,24 @@ final class NetworkBufferTypes {
                     return new DeathLocation(buffer.read(STRING), buffer.read(BLOCK_POSITION));
                 }
                 return null;
+            });
+    static final TypeImpl<CatMeta.Color> CAT_VARIANT = new TypeImpl<>(CatMeta.Color.class,
+            (buffer, value) -> {
+                buffer.write(VAR_INT, value.ordinal());
+                return -1;
+            },
+            buffer -> {
+                final int ordinal = buffer.read(VAR_INT);
+                return CatMeta.Color.values()[ordinal];
+            });
+    static final TypeImpl<FrogMeta.Variant> FROG_VARIANT = new TypeImpl<>(FrogMeta.Variant.class,
+            (buffer, value) -> {
+                buffer.write(VAR_INT, value.ordinal());
+                return -1;
+            },
+            buffer -> {
+                final int ordinal = buffer.read(VAR_INT);
+                return FrogMeta.Variant.values()[ordinal];
             });
 
     record TypeImpl<T>(@NotNull Class<T> type,


### PR DESCRIPTION
Resolves https://github.com/Minestom/Minestom/issues/1832

Frog and Cat entities have special metadata values for their variants (see https://wiki.vg/Entity_metadata#Cat). This uses those types to ensure the type parameter of the meta is correct.