### PR TITLE
Add missing entity pose

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1774,6 +1774,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
         DYING,
         CROAKING,
         USING_TONGUE,
+        SITTING,
         ROARING,
         SNIFFING,
         EMERGING,


### PR DESCRIPTION
In Minecraft Vanilla 1.20.1 there are 15 Entity Poses. In Minestom there are only 14 because the "Sitting" pose is missing. This causes the poses after the missing one to be incorrect, since poses are determined by the enum's ordinal. 

Feel free to validate the existence of this pose in either the Minecraft Source Code or on wiki.vg: https://wiki.vg/Entity_metadata#Entity_Metadata_Format