### PR TITLE
A few fixes for the metadata api

### DIFF
--- a/src/main/java/net/minestom/server/entity/EntityTypeImpl.java
+++ b/src/main/java/net/minestom/server/entity/EntityTypeImpl.java
@@ -189,7 +189,7 @@ record EntityTypeImpl(Registry.EntityEntry registry) implements EntityType {
                 entry("minecraft:villager", VillagerMeta::new),
                 entry("minecraft:vindicator", VindicatorMeta::new),
                 entry("minecraft:wandering_trader", WanderingTraderMeta::new),
-                entry("minecraft:warden", EntityMeta::new), // TODO dedicated metadata
+                entry("minecraft:warden", WardenMeta::new),
                 entry("minecraft:witch", WitchMeta::new),
                 entry("minecraft:wither", WitherMeta::new),
                 entry("minecraft:wither_skeleton", WitherSkeletonMeta::new),

--- a/src/main/java/net/minestom/server/entity/EntityTypeImpl.java
+++ b/src/main/java/net/minestom/server/entity/EntityTypeImpl.java
@@ -88,7 +88,7 @@ record EntityTypeImpl(Registry.EntityEntry registry) implements EntityType {
                 entry("minecraft:blaze", BlazeMeta::new),
                 entry("minecraft:block_display", BlockDisplayMeta::new),
                 entry("minecraft:boat", BoatMeta::new),
-                entry("minecraft:chest_boat", EntityMeta::new), // TODO dedicated metadata
+                entry("minecraft:chest_boat", BoatMeta::new),
                 entry("minecraft:camel", CamelMeta::new),
                 entry("minecraft:cat", CatMeta::new),
                 entry("minecraft:cave_spider", CaveSpiderMeta::new),

--- a/src/main/java/net/minestom/server/entity/metadata/animal/FrogMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/FrogMeta.java
@@ -21,14 +21,10 @@ public class FrogMeta extends AnimalMeta {
         super.metadata.setIndex(OFFSET, Metadata.FrogVariant(value));
     }
 
-    public int getTongueTarget() {
-        return super.metadata.getIndex(OFFSET + 1, 0);
+    public @Nullable Integer getTongueTarget() {
+        return super.metadata.getIndex(OFFSET + 1, null);
     }
 
-    public void setTongueTarget(int value) {
-        //Backwards compat
-        setTongueTarget(Integer.valueOf(value));
-    }
 
     public void setTongueTarget(@Nullable Integer value) {
         super.metadata.setIndex(OFFSET + 1, Metadata.OptVarInt(value));

--- a/src/main/java/net/minestom/server/entity/metadata/animal/FrogMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/FrogMeta.java
@@ -3,6 +3,7 @@ package net.minestom.server.entity.metadata.animal;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Metadata;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FrogMeta extends AnimalMeta {
     public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
@@ -25,8 +26,14 @@ public class FrogMeta extends AnimalMeta {
     }
 
     public void setTongueTarget(int value) {
+        //Backwards compat
+        setTongueTarget(Integer.valueOf(value));
+    }
+
+    public void setTongueTarget(@Nullable Integer value) {
         super.metadata.setIndex(OFFSET + 1, Metadata.OptVarInt(value));
     }
+
 
     public enum Variant {
         TEMPERATE,

--- a/src/main/java/net/minestom/server/entity/metadata/animal/GoatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/GoatMeta.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class GoatMeta extends AnimalMeta {
     public static final byte OFFSET = AnimalMeta.MAX_OFFSET;
-    public static final byte MAX_OFFSET = OFFSET + 1;
+    public static final byte MAX_OFFSET = OFFSET + 3;
 
     public GoatMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
         super(entity, metadata);

--- a/src/main/java/net/minestom/server/entity/metadata/animal/GoatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/animal/GoatMeta.java
@@ -19,4 +19,20 @@ public class GoatMeta extends AnimalMeta {
     public void setScreaming(boolean screaming) {
         metadata.setIndex(OFFSET, Metadata.Boolean(screaming));
     }
+
+    public boolean hasLeftHorn() {
+        return metadata.getIndex(OFFSET + 1, true);
+    }
+
+    public void setLeftHorn(boolean leftHorn) {
+        metadata.setIndex(OFFSET + 1, Metadata.Boolean(leftHorn));
+    }
+
+    public boolean hasRightHorn() {
+        return metadata.getIndex(OFFSET + 2, true);
+    }
+
+    public void setRightHorn(boolean rightHorn) {
+        metadata.setIndex(OFFSET + 2, Metadata.Boolean(rightHorn));
+    }
 }

--- a/src/main/java/net/minestom/server/entity/metadata/monster/WardenMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/WardenMeta.java
@@ -1,0 +1,24 @@
+package net.minestom.server.entity.metadata.monster;
+
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.Metadata;
+import org.jetbrains.annotations.NotNull;
+
+public class WardenMeta extends MonsterMeta {
+
+    public static final byte OFFSET = MonsterMeta.MAX_OFFSET;
+    public static final byte MAX_OFFSET = OFFSET + 1;
+
+    public WardenMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
+        super(entity, metadata);
+    }
+
+    public int getAngerLevel() {
+        return super.metadata.getIndex(OFFSET, 0);
+    }
+
+    public void setAngerLevel(int value) {
+        super.metadata.setIndex(OFFSET, Metadata.VarInt(value));
+    }
+
+}

--- a/src/main/java/net/minestom/server/entity/metadata/monster/raider/PillagerMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/monster/raider/PillagerMeta.java
@@ -6,10 +6,18 @@ import org.jetbrains.annotations.NotNull;
 
 public class PillagerMeta extends AbstractIllagerMeta {
     public static final byte OFFSET = AbstractIllagerMeta.MAX_OFFSET;
-    public static final byte MAX_OFFSET = OFFSET + 0;
+    public static final byte MAX_OFFSET = OFFSET + 1;
 
     public PillagerMeta(@NotNull Entity entity, @NotNull Metadata metadata) {
         super(entity, metadata);
+    }
+
+    public boolean isChargingCrossbow() {
+        return super.metadata.getIndex(OFFSET, false);
+    }
+
+    public void setChargingCrossbow(boolean value) {
+        super.metadata.setIndex(OFFSET, Metadata.Boolean(value));
     }
 
 }

--- a/src/main/java/net/minestom/server/entity/metadata/other/BoatMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/other/BoatMeta.java
@@ -76,7 +76,10 @@ public class BoatMeta extends EntityMeta {
         BIRCH,
         JUNGLE,
         ACACIA,
-        DARK_OAK;
+        CHERRY,
+        DARK_OAK,
+        MANGROVE,
+        BAMBOO;
 
         private final static Type[] VALUES = values();
     }

--- a/src/main/java/net/minestom/server/entity/metadata/water/DolphinMeta.java
+++ b/src/main/java/net/minestom/server/entity/metadata/water/DolphinMeta.java
@@ -23,20 +23,19 @@ public class DolphinMeta extends WaterAnimalMeta {
         super.metadata.setIndex(OFFSET, Metadata.Position(value));
     }
 
-    public boolean isCanFindTreasure() {
+    public boolean isHasFish() {
         return super.metadata.getIndex(OFFSET + 1, false);
     }
 
-    public void setCanFindTreasure(boolean value) {
+    public void setHasFish(boolean value) {
         super.metadata.setIndex(OFFSET + 1, Metadata.Boolean(value));
     }
 
-    public boolean isHasFish() {
-        return super.metadata.getIndex(OFFSET + 2, false);
+    public int getMoistureLevel() {
+        return super.metadata.getIndex(OFFSET + 2, 2400);
     }
 
-    public void setHasFish(boolean value) {
-        super.metadata.setIndex(OFFSET + 2, Metadata.Boolean(value));
+    public void setMoistureLevel(int value) {
+        super.metadata.setIndex(OFFSET + 2, Metadata.VarInt(value));
     }
-
 }


### PR DESCRIPTION
Since I am currently implementing a replay system in minestom that replays entity actions from a paper server, I needed to have access to every single entity meta field and found out that Minestom was not fully up to Minecrafts spec.

I fixed the following issues:
- The new boat types of 1.20.1 were missing
- Goat horns could not be customized
- Pillagers were missing their crossbow field
- Chestboats had no metadata
- Wardens had no metadata
- Removed a non-existent field from Dolphin meta and added missing moisture level
- It was not possible to set a null integer for an optional var int field in frogs (tounge target)

As for backwards compatibility, the Dolphin change is breaking. The frog change will only cause issues with already compiled code, as it is changing a methods signature. (int -> Integer)