### PR TITLE
Fix low accuracy tick rate

### DIFF
--- a/src/main/java/net/minestom/server/ServerProcessImpl.java
+++ b/src/main/java/net/minestom/server/ServerProcessImpl.java
@@ -269,6 +269,9 @@ final class ServerProcessImpl implements ServerProcess {
             // Flush all waiting packets
             PacketUtils.flush();
 
+            // Server connection tick
+            server().tick();
+
             // Monitoring
             {
                 final double acquisitionTimeMs = Acquirable.resetAcquiringTime() / 1e6D;

--- a/src/main/java/net/minestom/server/network/socket/Server.java
+++ b/src/main/java/net/minestom/server/network/socket/Server.java
@@ -94,6 +94,10 @@ public final class Server {
         }, "Ms-entrypoint").start();
     }
 
+    public void tick() {
+        this.workers.forEach(Worker::tick);
+    }
+
     public boolean isOpen() {
         return !stop;
     }

--- a/src/main/java/net/minestom/server/network/socket/Worker.java
+++ b/src/main/java/net/minestom/server/network/socket/Worker.java
@@ -38,6 +38,10 @@ public final class Worker extends MinestomThread {
         }
     }
 
+    public void tick() {
+        this.selector.wakeup();
+    }
+
     @Override
     public void run() {
         while (server.isOpen()) {
@@ -85,7 +89,7 @@ public final class Worker extends MinestomThread {
                         MinecraftServer.getExceptionManager().handleException(t);
                         connection.disconnect();
                     }
-                }, MinecraftServer.TICK_MS);
+                });
             } catch (Exception e) {
                 MinecraftServer.getExceptionManager().handleException(e);
             }
@@ -117,7 +121,6 @@ public final class Worker extends MinestomThread {
             socket.setTcpNoDelay(Server.NO_DELAY);
             socket.setSoTimeout(30 * 1000); // 30 seconds
         }
-        this.selector.wakeup();
     }
 
     public MessagePassingQueue<Runnable> queue() {

--- a/src/main/java/net/minestom/server/thread/TickSchedulerThread.java
+++ b/src/main/java/net/minestom/server/thread/TickSchedulerThread.java
@@ -10,6 +10,9 @@ import java.util.concurrent.locks.LockSupport;
 public final class TickSchedulerThread extends MinestomThread {
     private final ServerProcess serverProcess;
 
+    private final long startTickNs = System.nanoTime();
+    private long tick = 1;
+
     public TickSchedulerThread(ServerProcess serverProcess) {
         super(MinecraftServer.THREAD_NAME_TICK_SCHEDULER);
         this.serverProcess = serverProcess;
@@ -28,10 +31,6 @@ public final class TickSchedulerThread extends MinestomThread {
             fixTickRate(tickNs);
         }
     }
-
-
-    private final long startTickNs = System.nanoTime();
-    private long tick = 1;
 
     private void fixTickRate(long tickNs) {
         long nextTickNs = startTickNs + (tickNs * tick);


### PR DESCRIPTION
The accuracy of Minestom's tick scheduler is not very high, which can cause a difference between the client's tick rate and the server's tick rate, making the entity's movements unstable.

### Related Issues(probably)
https://github.com/Minestom/Minestom/issues/1791

### TestCode
```Java
MinecraftServer.getGlobalEventHandler().addListener(PlayerStartSneakingEvent.class, event -> {
    var player = event.getPlayer();
    var entity = new Entity(EntityType.ITEM_DISPLAY) {
        private long lastTime = System.nanoTime() / 1000000;
        @Override
        public void tick(long time) {
            var currentTime = System.nanoTime() / 1000000;
            player.sendMessage((currentTime - lastTime) + "[ms]");
            lastTime = currentTime;

            super.teleport(super.position.add(0.15, 0.0, 0.0));
        }
    };
    ((ItemDisplayMeta) entity.getEntityMeta()).setItemStack(ItemStack.of(Material.DIAMOND_PICKAXE));
    entity.setInstance(player.getInstance(), player.getPosition());
});
```
Before
![before](https://github.com/hollow-cube/minestom-ce/assets/34712108/9796ee11-e6dd-4f3a-854a-267d68bf3185)
After
![after](https://github.com/hollow-cube/minestom-ce/assets/34712108/5fe2c211-74e8-49c9-84cf-18335dea6d29)