### PR TITLE
Add Entity::despawn and EntityDespawnEvent

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -273,7 +273,7 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     /**
      * Called right before an entity is removed
      */
-    public void despawn() {
+    protected void despawn() {
 
     }
 

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -270,6 +270,13 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
 
     }
 
+    /**
+     * Called right before an entity is removed
+     */
+    public void despawn() {
+
+    }
+
     public boolean isOnGround() {
         return onGround || EntityUtils.isOnGround(this) /* backup for levitating entities */;
     }
@@ -1484,11 +1491,20 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      */
     public void remove() {
         if (isRemoved()) return;
+
+        try {
+            EventDispatcher.call(new EntityDespawnEvent(this));
+            despawn();
+        } catch (Throwable t) {
+            MinecraftServer.getExceptionManager().handleException(t);
+        }
+
         // Remove passengers if any (also done with LivingEntity#kill)
         Set<Entity> passengers = getPassengers();
         if (!passengers.isEmpty()) passengers.forEach(this::removePassenger);
         final Entity vehicle = this.vehicle;
         if (vehicle != null) vehicle.removePassenger(this);
+
         MinecraftServer.process().dispatcher().removeElement(this);
         this.removed = true;
         Entity.ENTITY_BY_ID.remove(id);

--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1492,8 +1492,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
     public void remove() {
         if (isRemoved()) return;
 
+        EventDispatcher.call(new EntityDespawnEvent(this));
         try {
-            EventDispatcher.call(new EntityDespawnEvent(this));
             despawn();
         } catch (Throwable t) {
             MinecraftServer.getExceptionManager().handleException(t);

--- a/src/main/java/net/minestom/server/event/entity/EntityDespawnEvent.java
+++ b/src/main/java/net/minestom/server/event/entity/EntityDespawnEvent.java
@@ -1,0 +1,28 @@
+package net.minestom.server.event.entity;
+
+import net.minestom.server.entity.Entity;
+import net.minestom.server.event.trait.EntityInstanceEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called right before an entity is removed
+ */
+public class EntityDespawnEvent implements EntityInstanceEvent {
+
+    private final Entity entity;
+
+    public EntityDespawnEvent(@NotNull Entity entity) {
+        this.entity = entity;
+    }
+
+    /**
+     * Gets the entity who is about to be removed
+     *
+     * @return the entity
+     */
+    @NotNull
+    @Override
+    public Entity getEntity() {
+        return entity;
+    }
+}


### PR DESCRIPTION
There is spawn(), why not despawn()?

Overriding remove() would require having the isRemoved() check, so this method is simpler and more future-proof.