### PR TITLE
Remove default damage behaviour

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -558,8 +558,6 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
             // handle block contacts
             touchTick();
 
-            handleVoid();
-
             // Call the abstract update method
             update(time);
 
@@ -745,16 +743,6 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
      */
     public long getAliveTicks() {
         return ticks;
-    }
-
-    /**
-     * How does this entity handle being in the void?
-     */
-    protected void handleVoid() {
-        // Kill if in void
-        if (getInstance().isInVoid(this.position)) {
-            remove();
-        }
     }
 
     /**

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -64,11 +64,6 @@ public class LivingEntity extends Entity implements EquipmentHandler {
     private long fireExtinguishTime;
 
     /**
-     * Last time the fire damage was applied
-     */
-    private long lastFireDamageTime;
-
-    /**
      * Period, in ms, between two fire damage applications
      */
     private long fireDamagePeriod = 1000L;
@@ -189,15 +184,8 @@ public class LivingEntity extends Entity implements EquipmentHandler {
 
     @Override
     public void update(long time) {
-        if (isOnFire()) {
-            if (time > fireExtinguishTime) {
-                setOnFire(false);
-            } else {
-                if (time - lastFireDamageTime > fireDamagePeriod) {
-                    damage(DamageType.ON_FIRE, 1.0f);
-                    lastFireDamageTime = time;
-                }
-            }
+        if (isOnFire() && time > fireExtinguishTime) {
+            setOnFire(false);
         }
 
         // Items picking

--- a/src/main/java/net/minestom/server/entity/LivingEntity.java
+++ b/src/main/java/net/minestom/server/entity/LivingEntity.java
@@ -582,14 +582,6 @@ public class LivingEntity extends Entity implements EquipmentHandler {
         return new EntityPropertiesPacket(getEntityId(), List.copyOf(attributeModifiers.values()));
     }
 
-    @Override
-    protected void handleVoid() {
-        // Kill if in void
-        if (getInstance().isInVoid(this.position)) {
-            damage(DamageType.VOID, 10f);
-        }
-    }
-
     /**
      * Gets the time in ms between two fire damage applications.
      *

--- a/src/main/java/net/minestom/server/instance/Instance.java
+++ b/src/main/java/net/minestom/server/instance/Instance.java
@@ -367,9 +367,7 @@ public abstract class Instance implements Block.Getter, Block.Setter,
     public abstract boolean hasEnabledAutoChunkLoad();
 
     /**
-     * Determines whether a position in the void. If true, entities should take damage and die.
-     * <p>
-     * Always returning false allow entities to survive in the void.
+     * Determines whether a position in the void.
      *
      * @param point the point in the world
      * @return true if the point is inside the void


### PR DESCRIPTION
Removes void and fire damage handling that Minestom handles by default.
It's just not something that should be default behaviour.