### PR TITLE
Entity Position Sync fix

### DIFF
--- a/src/main/java/net/minestom/server/entity/Entity.java
+++ b/src/main/java/net/minestom/server/entity/Entity.java
@@ -1343,7 +1343,8 @@ public class Entity implements Viewable, Tickable, Schedulable, Snapshotable, Ev
                     lastSyncedPosition, onGround), this);
         } else if (viewChange) {
             PacketUtils.prepareViewablePacket(chunk, new EntityHeadLookPacket(getEntityId(), position.yaw()), this);
-            PacketUtils.prepareViewablePacket(chunk, new EntityRotationPacket(getEntityId(), position.yaw(), position.pitch(), onGround), this);
+            PacketUtils.prepareViewablePacket(chunk, EntityPositionAndRotationPacket.getPacket(getEntityId(), position,
+                    lastSyncedPosition, isOnGround()), this);
         }
         this.lastSyncedPosition = position;
     }


### PR DESCRIPTION
This pull request aims to fix an issue where a player's position can desync for other players if they rotate their head while not moving their position.

Before the fix:

https://github.com/hollow-cube/minestom-ce/assets/87914807/75b0c091-df4e-4f4a-8b7b-0d4fe628060d

After the fix:

https://github.com/hollow-cube/minestom-ce/assets/87914807/dbb3b8dc-8f18-4371-9c18-860b4450fad2

Related issue: #71 