### PR TITLE
Proper sound seeding

### DIFF
--- a/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java
+++ b/src/main/java/net/minestom/server/adventure/AdventurePacketConvertor.java
@@ -10,7 +10,6 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.title.Title;
 import net.kyori.adventure.title.TitlePart;
-import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.network.packet.server.ServerPacket;
@@ -20,6 +19,7 @@ import net.minestom.server.utils.TickUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Utility methods to convert adventure enums to their packet values.
@@ -101,7 +101,8 @@ public class AdventurePacketConvertor {
     }
 
     /**
-     * Creates a sound packet from a sound and a location.
+     * Creates a sound packet from a sound and a location.<br>
+     * Random variation by default unless a seed is provided in the {@link Sound}.
      *
      * @param sound the sound
      * @param x     the x coordinate
@@ -111,17 +112,19 @@ public class AdventurePacketConvertor {
      */
     public static @NotNull ServerPacket createSoundPacket(@NotNull Sound sound, double x, double y, double z) {
         final SoundEvent minestomSound = SoundEvent.fromNamespaceId(sound.name().asString());
+        final long seed = sound.seed().orElse(ThreadLocalRandom.current().nextLong());
         if (minestomSound == null) {
             return new SoundEffectPacket(sound.name().asString(), null, sound.source(),
-                    new Vec(x, y, z), sound.volume(), sound.pitch(), 0);
+                    new Vec(x, y, z), sound.volume(), sound.pitch(), seed);
         } else {
             return new SoundEffectPacket(minestomSound, null, sound.source(),
-                    new Vec(x, y, z), sound.volume(), sound.pitch(), 0);
+                    new Vec(x, y, z), sound.volume(), sound.pitch(), seed);
         }
     }
 
     /**
-     * Creates a sound effect packet from a sound and an emitter.
+     * Creates a sound effect packet from a sound and an emitter.<br>
+     * Random variation by default unless a seed is provided in the {@link Sound}.
      *
      * @param sound   the sound
      * @param emitter the emitter, must be an {@link Entity}
@@ -134,11 +137,12 @@ public class AdventurePacketConvertor {
             throw new IllegalArgumentException("you can only call this method with entities");
 
         final SoundEvent minestomSound = SoundEvent.fromNamespaceId(sound.name().asString());
+        final long seed = sound.seed().orElse(ThreadLocalRandom.current().nextLong());
 
         if (minestomSound != null) {
-            return new EntitySoundEffectPacket(minestomSound, null, sound.source(), entity.getEntityId(), sound.volume(), sound.pitch(), 0);
+            return new EntitySoundEffectPacket(minestomSound, null, sound.source(), entity.getEntityId(), sound.volume(), sound.pitch(), seed);
         } else {
-            return new EntitySoundEffectPacket(sound.name().asString(), null, sound.source(), entity.getEntityId(), sound.volume(), sound.pitch(), 0);
+            return new EntitySoundEffectPacket(sound.name().asString(), null, sound.source(), entity.getEntityId(), sound.volume(), sound.pitch(), seed);
         }
     }
 


### PR DESCRIPTION
This issue aims to solve an issue where the AdventurePacketConvertor#createSoundPacket() methods don't actually utilize the seed provided in the adventure sound object. If a seed is not provided, a random seed is used rather than zero for better expected default behavior.