### PR TITLE
Add required repository to installation instructions

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -41,7 +41,7 @@ and can be installed like the following (Gradle/Groovy):
 ```groovy
 repositories {
     mavenCentral()
-    maven { url = 'https://jitpack.io' }
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {

--- a/.github/README.md
+++ b/.github/README.md
@@ -41,6 +41,7 @@ and can be installed like the following (Gradle/Groovy):
 ```groovy
 repositories {
     mavenCentral()
+    maven { url = 'https://jitpack.io' }
 }
 
 dependencies {


### PR DESCRIPTION
An error occurs if jitpack is not in the repositories, due to a dependency