### PR TITLE
fix incorrect skin layer setting

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -283,6 +283,8 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
 
         sendPacket(new SpawnPositionPacket(respawnPoint, 0));
 
+        sendPacket(getMetadataPacket());
+
         // Add player to list with spawning skin
         PlayerSkin profileSkin = null;
         if (playerConnection instanceof PlayerSocketConnection socketConnection) {


### PR DESCRIPTION
This seems to be the right place to send the metadata without interfering with the configuration state