### PR TITLE
update: explicitly send packets at end of tick system property

### DIFF
--- a/src/main/java/net/minestom/server/network/socket/Server.java
+++ b/src/main/java/net/minestom/server/network/socket/Server.java
@@ -132,6 +132,10 @@ public final class Server {
         return port;
     }
 
+    public synchronized void wakeupWorkers() {
+        workers.forEach(worker -> worker.selector.wakeup());
+    }
+
     private Worker findWorker() {
         this.index = ++index % WORKER_COUNT;
         return workers.get(index);


### PR DESCRIPTION
Currently the workers are sluggish with their packet sending, setting this property to true makes a world of difference to the responsiveness of Minestom servers.
I have been using this on my server for about half a year without any issue.