### PR TITLE
Fix a long "loading terrain" screen with Player.setSkin()

### DIFF
--- a/src/main/java/net/minestom/server/entity/Player.java
+++ b/src/main/java/net/minestom/server/entity/Player.java
@@ -1175,6 +1175,8 @@ public class Player extends LivingEntity implements CommandSender, Localizable, 
         sendPacket(destroyEntitiesPacket);
         sendPacket(addPlayerPacket);
         sendPacket(respawnPacket);
+        // Tell the client to leave the loading terrain screen
+        sendPacket(new ChangeGameStatePacket(ChangeGameStatePacket.Reason.LEVEL_CHUNKS_LOAD_START, 0));
         refreshClientStateAfterRespawn();
 
         {


### PR DESCRIPTION
When using `Player.setSkin()`, the player would get a "loading terrain" screen for a while, this pr fixes that by sending `ChangeGameStatePacket(ChangeGameStatePacket.Reason.LEVEL_CHUNKS_LOAD_START, 0)` after the respawn packet.