### PR TITLE
Send Lighting Immediately

### DIFF
--- a/demo/src/main/java/net/minestom/demo/Main.java
+++ b/demo/src/main/java/net/minestom/demo/Main.java
@@ -71,6 +71,7 @@ public class Main {
         commandManager.register(new ConfigCommand());
         commandManager.register(new SidebarCommand());
         commandManager.register(new SetEntityType());
+        commandManager.register(new RelightCommand());
 
         commandManager.setUnknownCommandCallback((sender, command) -> sender.sendMessage(Component.text("Unknown command", NamedTextColor.RED)));
 

--- a/demo/src/main/java/net/minestom/demo/PlayerInit.java
+++ b/demo/src/main/java/net/minestom/demo/PlayerInit.java
@@ -170,8 +170,16 @@ public class PlayerInit {
         InstanceManager instanceManager = MinecraftServer.getInstanceManager();
 
         InstanceContainer instanceContainer = instanceManager.createInstanceContainer(DimensionType.OVERWORLD);
-        instanceContainer.setGenerator(unit -> unit.modifier().fillHeight(0, 40, Block.STONE));
+        instanceContainer.setGenerator(unit -> {
+            unit.modifier().fillHeight(0, 40, Block.STONE);
+
+            if (unit.absoluteStart().blockY() < 40 && unit.absoluteEnd().blockY() > 40) {
+                unit.modifier().setBlock(unit.absoluteStart().blockX(), 40, unit.absoluteStart().blockZ(), Block.TORCH);
+            }
+        });
         instanceContainer.setChunkSupplier(LightingChunk::new);
+        instanceContainer.setTimeRate(0);
+        instanceContainer.setTime(18000);
 
 //        var i2 = new InstanceContainer(UUID.randomUUID(), DimensionType.OVERWORLD, null, NamespaceID.from("minestom:demo"));
 //        instanceManager.registerInstance(i2);

--- a/demo/src/main/java/net/minestom/demo/PlayerInit.java
+++ b/demo/src/main/java/net/minestom/demo/PlayerInit.java
@@ -193,6 +193,8 @@ public class PlayerInit {
         // CompletableFuture.runAsync(() -> {
         //     CompletableFuture.allOf(chunks.toArray(CompletableFuture[]::new)).join();
         //     System.out.println("load end");
+        //     LightingChunk.relight(instanceContainer, instanceContainer.getChunks());
+        //     System.out.println("light end");
         // });
 
         inventory = new Inventory(InventoryType.CHEST_1_ROW, Component.text("Test inventory"));

--- a/demo/src/main/java/net/minestom/demo/commands/RelightCommand.java
+++ b/demo/src/main/java/net/minestom/demo/commands/RelightCommand.java
@@ -1,0 +1,21 @@
+package net.minestom.demo.commands;
+
+import net.minestom.server.command.builder.Command;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.LightingChunk;
+
+public class RelightCommand extends Command {
+    public RelightCommand() {
+        super("relight");
+        setDefaultExecutor((source, args) -> {
+            if (source instanceof Player player) {
+                long start = System.currentTimeMillis();
+                source.sendMessage("Relighting...");
+                LightingChunk.relight(player.getInstance(), player.getInstance().getChunks());
+                source.sendMessage("Relighted " + player.getInstance().getChunks().size() + " chunks in " + (System.currentTimeMillis() - start) + "ms");
+                player.getInstance().getChunks().forEach(chunk -> chunk.sendChunk(player));
+                source.sendMessage("Chunks Received");
+            }
+        });
+    }
+}

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -210,24 +210,7 @@ public class DynamicChunk extends Chunk {
     }
 
     private @NotNull ChunkDataPacket createChunkPacket() {
-        final NBTCompound heightmapsNBT;
-        // TODO: don't hardcode heightmaps
-        // Heightmap
-        {
-            int dimensionHeight = getInstance().getDimensionType().getHeight();
-            int[] motionBlocking = new int[16 * 16];
-            int[] worldSurface = new int[16 * 16];
-            for (int x = 0; x < 16; x++) {
-                for (int z = 0; z < 16; z++) {
-                    motionBlocking[x + z * 16] = 0;
-                    worldSurface[x + z * 16] = dimensionHeight - 1;
-                }
-            }
-            final int bitsForHeight = MathUtils.bitsToRepresent(dimensionHeight);
-            heightmapsNBT = NBT.Compound(Map.of(
-                    "MOTION_BLOCKING", NBT.LongArray(encodeBlocks(motionBlocking, bitsForHeight)),
-                    "WORLD_SURFACE", NBT.LongArray(encodeBlocks(worldSurface, bitsForHeight))));
-        }
+        final NBTCompound heightmapsNBT = computeHeightmap();
         // Data
 
         final byte[] data;
@@ -242,6 +225,24 @@ public class DynamicChunk extends Chunk {
                 new ChunkData(heightmapsNBT, data, entries),
                 createLightData()
         );
+    }
+
+    protected NBTCompound computeHeightmap() {
+        // TODO: don't hardcode heightmaps
+        // Heightmap
+        int dimensionHeight = getInstance().getDimensionType().getHeight();
+        int[] motionBlocking = new int[16 * 16];
+        int[] worldSurface = new int[16 * 16];
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                motionBlocking[x + z * 16] = 0;
+                worldSurface[x + z * 16] = dimensionHeight - 1;
+            }
+        }
+        final int bitsForHeight = MathUtils.bitsToRepresent(dimensionHeight);
+        return NBT.Compound(Map.of(
+                "MOTION_BLOCKING", NBT.LongArray(encodeBlocks(motionBlocking, bitsForHeight)),
+                "WORLD_SURFACE", NBT.LongArray(encodeBlocks(worldSurface, bitsForHeight))));
     }
 
     @NotNull UpdateLightPacket createLightPacket() {
@@ -319,7 +320,7 @@ public class DynamicChunk extends Chunk {
             70409299, 70409299, 0, 69273666, 69273666, 0, 68174084, 68174084, 0, Integer.MIN_VALUE,
             0, 5};
 
-    private static long[] encodeBlocks(int[] blocks, int bitsPerEntry) {
+    static long[] encodeBlocks(int[] blocks, int bitsPerEntry) {
         final long maxEntryValue = (1L << bitsPerEntry) - 1;
         final char valuesPerLong = (char) (64 / bitsPerEntry);
         final int magicIndex = 3 * (valuesPerLong - 1);

--- a/src/main/java/net/minestom/server/instance/DynamicChunk.java
+++ b/src/main/java/net/minestom/server/instance/DynamicChunk.java
@@ -238,44 +238,17 @@ public class DynamicChunk extends Chunk {
                     }));
         }
 
-        if (this instanceof LightingChunk light) {
-            if (light.lightCache.isValid()) {
-                return new ChunkDataPacket(chunkX, chunkZ,
-                        new ChunkData(heightmapsNBT, data, entries),
-                        createLightData(true));
-            } else {
-                // System.out.println("Regenerating light for chunk " + chunkX + " " + chunkZ);
-                LightingChunk.updateAfterGeneration(light);
-                return new ChunkDataPacket(chunkX, chunkZ,
-                        new ChunkData(heightmapsNBT, data, entries),
-                        createEmptyLight());
-            }
-        }
-
         return new ChunkDataPacket(chunkX, chunkZ,
                 new ChunkData(heightmapsNBT, data, entries),
-                createLightData(true)
+                createLightData()
         );
     }
 
     @NotNull UpdateLightPacket createLightPacket() {
-        return new UpdateLightPacket(chunkX, chunkZ, createLightData(false));
+        return new UpdateLightPacket(chunkX, chunkZ, createLightData());
     }
 
-    private LightData createEmptyLight() {
-        BitSet skyMask = new BitSet();
-        BitSet blockMask = new BitSet();
-        BitSet emptySkyMask = new BitSet();
-        BitSet emptyBlockMask = new BitSet();
-        List<byte[]> skyLights = new ArrayList<>();
-        List<byte[]> blockLights = new ArrayList<>();
-
-        return new LightData(skyMask, blockMask,
-                emptySkyMask, emptyBlockMask,
-                skyLights, blockLights);
-    }
-
-    protected LightData createLightData(boolean sendLater) {
+    protected LightData createLightData() {
         BitSet skyMask = new BitSet();
         BitSet blockMask = new BitSet();
         BitSet emptySkyMask = new BitSet();

--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -140,7 +140,6 @@ public class LightingChunk extends DynamicChunk {
 
     @Override
     protected NBTCompound computeHeightmap() {
-        // TODO: don't hardcode heightmaps
         // Heightmap
         int[] heightmap = getHeightmap();
         int dimensionHeight = getInstance().getDimensionType().getHeight();
@@ -315,10 +314,12 @@ public class LightingChunk extends DynamicChunk {
         for (Chunk chunk : chunks) {
             if (chunk == null) continue;
             for (int section = chunk.minSection; section < chunk.maxSection; section++) {
-                chunk.getSection(section).blockLight().invalidate();
-                chunk.getSection(section).skyLight().invalidate();
+                if (chunk instanceof LightingChunk) {
+                    chunk.getSection(section).blockLight().invalidate();
+                    chunk.getSection(section).skyLight().invalidate();
 
-                sections.add(new Vec(chunk.getChunkX(), section, chunk.getChunkZ()));
+                    sections.add(new Vec(chunk.getChunkX(), section, chunk.getChunkZ()));
+                }
             }
         }
 

--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -227,9 +227,8 @@ public class LightingChunk extends DynamicChunk {
                 }
             }
 
-            Set<Chunk> finalCombined = combined;
             MinecraftServer.getSchedulerManager().scheduleNextTick(() -> {
-                for (Chunk chunk : finalCombined) {
+                for (Chunk chunk : combined) {
                     if (chunk instanceof LightingChunk light) {
                         if (light.initialLightingSent) {
                             light.lightCache.invalidate();
@@ -323,12 +322,10 @@ public class LightingChunk extends DynamicChunk {
                 if (chunkCheck == null) continue;
 
                 if (chunkCheck instanceof LightingChunk lighting) {
-                    if (x == 0 && z == 0) continue;
                     if (lighting.highestBlock > highestRegionPoint) highestRegionPoint = lighting.highestBlock;
                 }
             }
         }
-
 
         for (int x = point.blockX() - 1; x <= point.blockX() + 1; x++) {
             for (int z = point.blockZ() - 1; z <= point.blockZ() + 1; z++) {

--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -131,7 +131,6 @@ public class LightingChunk extends DynamicChunk {
 
     @Override
     protected void onLoad() {
-        // Prefetch the chunk packet so that lazy lighting is computed
         chunkLoaded = true;
     }
 
@@ -143,7 +142,7 @@ public class LightingChunk extends DynamicChunk {
     protected NBTCompound computeHeightmap() {
         // TODO: don't hardcode heightmaps
         // Heightmap
-        int[] heightmap = calculateHeightMap();
+        int[] heightmap = getHeightmap();
         int dimensionHeight = getInstance().getDimensionType().getHeight();
         final int bitsForHeight = MathUtils.bitsToRepresent(dimensionHeight);
         return NBT.Compound(Map.of(
@@ -151,7 +150,8 @@ public class LightingChunk extends DynamicChunk {
                 "WORLD_SURFACE", NBT.LongArray(encodeBlocks(heightmap, bitsForHeight))));
     }
 
-    public int[] calculateHeightMap() {
+    // Lazy compute heightmap
+    public int[] getHeightmap() {
         if (this.heightmap != null) return this.heightmap;
         var heightmap = new int[CHUNK_SIZE_X * CHUNK_SIZE_Z];
 

--- a/src/main/java/net/minestom/server/instance/LightingChunk.java
+++ b/src/main/java/net/minestom/server/instance/LightingChunk.java
@@ -25,9 +25,6 @@ import static net.minestom.server.instance.light.LightCompute.emptyContent;
 
 public class LightingChunk extends DynamicChunk {
 
-    // private static final int LIGHTING_CHUNKS_PER_SEND = Integer.getInteger("minestom.lighting.chunks-per-send", 10);
-    // private static final int LIGHTING_CHUNKS_SEND_DELAY = Integer.getInteger("minestom.lighting.chunks-send-delay", 100);
-
     private static final ExecutorService pool = Executors.newWorkStealingPool();
 
     private int[] heightmap;

--- a/src/main/java/net/minestom/server/instance/light/BlockLight.java
+++ b/src/main/java/net/minestom/server/instance/light/BlockLight.java
@@ -26,7 +26,7 @@ final class BlockLight implements Light {
     private byte[] contentPropagation;
     private byte[] contentPropagationSwap;
 
-    private boolean isValidBorders = true;
+    private boolean isValidBorders = false;
     private boolean needsSend = true;
 
     private Set<Point> toUpdateSet = new HashSet<>();
@@ -212,6 +212,11 @@ final class BlockLight implements Light {
         boolean res = needsSend;
         needsSend = false;
         return res;
+    }
+
+    @Override
+    public void setRequiresSend(boolean b) {
+        this.needsSend = b;
     }
 
     private void clearCache() {

--- a/src/main/java/net/minestom/server/instance/light/Light.java
+++ b/src/main/java/net/minestom/server/instance/light/Light.java
@@ -27,6 +27,7 @@ public interface Light {
     }
 
     boolean requiresSend();
+    void setRequiresSend(boolean b);
 
     @ApiStatus.Internal
     byte[] array();

--- a/src/main/java/net/minestom/server/instance/light/SkyLight.java
+++ b/src/main/java/net/minestom/server/instance/light/SkyLight.java
@@ -14,9 +14,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static net.minestom.server.instance.light.LightCompute.*;
 
@@ -59,7 +57,7 @@ final class SkyLight implements Light {
         ShortArrayFIFOQueue lightSources = new ShortArrayFIFOQueue();
 
         if (c instanceof LightingChunk lc) {
-            int[] heightmap = lc.calculateHeightMap();
+            int[] heightmap = lc.getHeightmap();
             int maxY = c.getInstance().getDimensionType().getMinY() + c.getInstance().getDimensionType().getHeight();
             int sectionMaxY = (sectionY + 1) * 16 - 1;
             int sectionMinY = sectionY * 16;

--- a/src/main/java/net/minestom/server/instance/light/SkyLight.java
+++ b/src/main/java/net/minestom/server/instance/light/SkyLight.java
@@ -27,7 +27,7 @@ final class SkyLight implements Light {
     private byte[] contentPropagation;
     private byte[] contentPropagationSwap;
 
-    private boolean isValidBorders = true;
+    private boolean isValidBorders = false;
     private boolean needsSend = true;
 
     private Set<Point> toUpdateSet = new HashSet<>();
@@ -238,6 +238,11 @@ final class SkyLight implements Light {
         boolean res = needsSend;
         needsSend = false;
         return res;
+    }
+
+    @Override
+    public void setRequiresSend(boolean b) {
+        this.needsSend = b;
     }
 
     private void clearCache() {


### PR DESCRIPTION
Looks like the lighting algorithm is fast enough. Removed all the complex async sending.
This commit also reduces the data sent by a lot. Vanilla assumes that sections above the heightmap are fully lit, so we don't need to send them. Previously we were sending them and it was destroying client performance.